### PR TITLE
Fix RemoteMapJournalSource - start from oldest

### DIFF
--- a/streaming/map-journal-source/src/main/java/MapJournalSource.java
+++ b/streaming/map-journal-source/src/main/java/MapJournalSource.java
@@ -45,7 +45,7 @@ public class MapJournalSource {
         try {
             Pipeline p = Pipeline.create();
             p.drawFrom(Sources.<Integer, Integer, Integer>mapJournal(MAP_NAME, e -> e.getType() == EntryEventType.ADDED,
-                    EventJournalMapEvent::getNewValue, true))
+                    EventJournalMapEvent::getNewValue, false))
              .drainTo(Sinks.list(SINK_NAME));
 
             jet.newJob(p);

--- a/streaming/map-journal-source/src/main/java/RemoteMapJournalSource.java
+++ b/streaming/map-journal-source/src/main/java/RemoteMapJournalSource.java
@@ -56,7 +56,7 @@ public class RemoteMapJournalSource {
 
             Pipeline p = Pipeline.create();
             p.drawFrom(Sources.<Integer, Integer, Integer>remoteMapJournal(MAP_NAME, clientConfig,
-                    e -> e.getType() == EntryEventType.ADDED, EventJournalMapEvent::getNewValue, true))
+                    e -> e.getType() == EntryEventType.ADDED, EventJournalMapEvent::getNewValue, false))
              .drainTo(Sinks.list(SINK_NAME));
 
             localJet.newJob(p);


### PR DESCRIPTION
We insert fixed number of items to the map - it seems logical that we'll read the same number of items. If we start from latest, we might miss some of the earlier items.

Based on https://groups.google.com/d/msgid/hazelcast-jet/b10ba4b4-83b0-41d4-99ac-5ada12c9f02a%40googlegroups.com?utm_medium=email&utm_source=footer