### PR TITLE
Fix the dependency conflict issue 

### DIFF
--- a/integration/pcf/pom.xml
+++ b/integration/pcf/pom.xml
@@ -46,6 +46,11 @@
     </dependencyManagement>
 
     <dependencies>
+       <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
Fix the dependency conflict issue #192 by reversing the declaration order of **_log4j:log4j:jar:1.2.12:compile_** and **_org.springframework.boot:spring-boot-starter-web:jar:1.4.3.RELEASE_** in pom file, as **_org.springframework.boot:spring-boot-starter-web:jar:1.4.3.RELEASE_** transitively introduce the **_org.slf4j:log4j-over-slf4j:jar:1.7.22:compile_**.

This fix will not affect other libraries or class, except the above duplicate class.

Thank you for your attention.