### PR TITLE
Port of learning basics from hazelcast code samples

### DIFF
--- a/learning-basics/README.md
+++ b/learning-basics/README.md
@@ -1,0 +1,18 @@
+# Learning Basics
+
+Code samples for Hazelcast Jet related to configuration and logging basics.
+
+## [Configuring with YAML](configure-yaml)
+
+This sample shows, how to to configure Hazelcast Jet instance with YAML files.
+
+## [Configuring with XML](configure-xml)
+
+This sample shows, how to to configure Hazelcast Jet instance with XML files.
+
+## [Configuring Logging](configure-logging)
+
+This sample shows, how to to configure logging for Hazelcast Jet instance.
+
+
+

--- a/learning-basics/configure-logging/README.md
+++ b/learning-basics/configure-logging/README.md
@@ -1,0 +1,41 @@
+# Configure Logging
+
+The samples in this module demonstrate how to configure logging for Hazelcast Jet.
+
+## Building the application
+
+```
+mvn clean package
+```
+
+## Running the application
+
+To start the application with each logging configuration option, execute 
+the following commands:
+
+### JDK Logging
+
+```
+./start-jdk.sh
+```
+
+### Log4j Logging
+
+```
+./start-log4j.sh
+```
+
+### Slf4j Logging
+
+```
+./start-slf4j.sh
+```
+
+### No Logging
+
+```
+./start-none.sh
+```
+
+For more information about logging, please refer to the [Logging Configuration](https://docs.hazelcast.org/docs/jet/latest/manual/#configure-logging)
+section on reference manual.

--- a/learning-basics/configure-logging/pom.xml
+++ b/learning-basics/configure-logging/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>learning-basics</artifactId>
+        <groupId>com.hazelcast.jet.samples</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+
+    <artifactId>configure-logging</artifactId>
+    <name>Learning Basics - Logging Configuration</name>
+
+    <description>
+        Learning Basics - Logging Configuration
+    </description>
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <log4j.version>1.2.12</log4j.version>
+        <slf4j.api.version>1.6.6</slf4j.api.version>
+        <slf4j-log4j12.version>1.6.6</slf4j-log4j12.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <!-- if you want to make use of log4j, the following dependency needs to be included-->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <!-- if you want to make use of sl4j, the following dependencies need to be included-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j-log4j12.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/learning-basics/configure-logging/src/main/java/JetInstance.java
+++ b/learning-basics/configure-logging/src/main/java/JetInstance.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.jet.Jet;
+
+public class JetInstance {
+    public static void main(String[] args) {
+        Jet.newJetInstance();
+    }
+}

--- a/learning-basics/configure-logging/src/main/resources/log4j.properties
+++ b/learning-basics/configure-logging/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n

--- a/learning-basics/configure-logging/start-jdk.sh
+++ b/learning-basics/configure-logging/start-jdk.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -cp target/lib/*:target/classes -Dhazelcast.logging.type=jdk  JetInstance

--- a/learning-basics/configure-logging/start-log4j.sh
+++ b/learning-basics/configure-logging/start-log4j.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+#add '-Dlog4j.debug' if logging doesn't work
+java -cp target/lib/*:target/classes -Dhazelcast.logging.type=log4j  JetInstance

--- a/learning-basics/configure-logging/start-none.sh
+++ b/learning-basics/configure-logging/start-none.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -cp target/lib/*:target/classes -Dhazelcast.logging.type=none  JetInstance

--- a/learning-basics/configure-logging/start-slf4j.sh
+++ b/learning-basics/configure-logging/start-slf4j.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -cp target/lib/*:target/classes -Dhazelcast.logging.type=slf4j JetInstance

--- a/learning-basics/configure-xml/README.md
+++ b/learning-basics/configure-xml/README.md
@@ -1,0 +1,45 @@
+# XML Configuration
+
+The samples in this module demonstrate how to configure a Hazelcast Jet cluster with XML configuration.
+
+### Configuration Lookup
+
+Creating member instance with `Jet.newJetInstance()` looks for configuration files
+in multiple locations both in XML and YAML format. XML configuration takes precedence
+over YAML configuration in all locations resulting the following lookup order:
+1. The configuration passed in `hazelcast.jet.config` JVM argument, either XML or YAML
+2. `hazelcast-jet.xml` on the classpath
+3. `hazelcast-jet.yaml` on the classpath
+4. `hazelcast-jet.xml` in the working directory
+5. `hazelcast-jet.yaml` in the working directory
+6. default configuration `hazelcast-jet-default.xml`
+
+Similarly, the (Java) client instances created with `Jet.newJetClient()` follows
+the same lookup logic and order:
+1. The configuration passed in `hazelcast.client.config` JVM argument, either XML or YAML
+2. `hazelcast-client.xml` on the classpath
+3. `hazelcast-client.yaml` on the classpath
+4. `hazelcast-client.xml` in the working directory
+5. `hazelcast-client.yaml` in the working directory
+6. default configuration `hazelcast-jet-client-default.xml`
+
+The sample `ConfigLookup` demonstrates how the configuration files are located on the classpath and 
+how to use the locator logic to take only YAML configuration files into account. 
+
+### Loading XML Configuration Without Lookup
+
+If it is known that the cluster will be configured with XML configuration and no need for using the location 
+logic shown in the first sample, the following XML-specific `JetConfig` classes can be used:
+- `ClasspathXmlJetConfig`: loads the configuration from the classpath based on the provided filename
+- `FileSystemXmlJetConfig`: loads the configuration from the file system based on the provided filename
+- `UrlXmlJetConfig`: loads the configuration from the provided URL
+- `InMemoryXmlJetConfig`: loads the configuration from the provided `String` containing XML configuration 
+
+The sample `XmlJetConfigClasspath` loads the jet configuration `hazelcast-jet-sample.xml` from the classpath and 
+demonstrates variable replacement in XML configuration by defining the backup count and metrics configuration
+in variables taken from the system properties and then from a provided `Properties` instance.   
+
+#### Full XML Configuration Example
+
+There is a full example XML configuration in the distributed Hazelcast Jet jars, named `hazelcast-jet-full-example.xml`.
+This example file can be used for reference when writing XML configuration.

--- a/learning-basics/configure-xml/README.md
+++ b/learning-basics/configure-xml/README.md
@@ -9,8 +9,8 @@ in multiple locations both in XML and YAML format. XML configuration takes prece
 over YAML configuration in all locations resulting the following lookup order:
 1. The configuration passed in `hazelcast.jet.config` JVM argument, either XML or YAML
 2. `hazelcast-jet.xml` on the classpath
-3. `hazelcast-jet.yaml` on the classpath
-4. `hazelcast-jet.xml` in the working directory
+3. `hazelcast-jet.xml` in the working directory
+4. `hazelcast-jet.yaml` on the classpath
 5. `hazelcast-jet.yaml` in the working directory
 6. default configuration `hazelcast-jet-default.xml`
 
@@ -18,8 +18,8 @@ Similarly, the (Java) client instances created with `Jet.newJetClient()` follows
 the same lookup logic and order:
 1. The configuration passed in `hazelcast.client.config` JVM argument, either XML or YAML
 2. `hazelcast-client.xml` on the classpath
-3. `hazelcast-client.yaml` on the classpath
-4. `hazelcast-client.xml` in the working directory
+3. `hazelcast-client.xml` in the working directory
+4. `hazelcast-client.yaml` on the classpath
 5. `hazelcast-client.yaml` in the working directory
 6. default configuration `hazelcast-jet-client-default.xml`
 
@@ -29,11 +29,12 @@ how to use the locator logic to take only YAML configuration files into account.
 ### Loading XML Configuration Without Lookup
 
 If it is known that the cluster will be configured with XML configuration and no need for using the location 
-logic shown in the first sample, the following XML-specific `JetConfig` classes can be used:
-- `ClasspathXmlJetConfig`: loads the configuration from the classpath based on the provided filename
-- `FileSystemXmlJetConfig`: loads the configuration from the file system based on the provided filename
-- `UrlXmlJetConfig`: loads the configuration from the provided URL
-- `InMemoryXmlJetConfig`: loads the configuration from the provided `String` containing XML configuration 
+logic shown in the first sample, the following XML-specific config loader utility methods on the `JetConfig` 
+class can be used:
+- `JetConfig.loadFromClasspath()`: loads the configuration from the classpath based on the provided filename
+- `JetConfig.loadFromFile()`     : loads the configuration from the file system based on the provided filename
+- `JetConfig.loadXmlFromStream()`: loads the configuration from the provided input stream
+- `JetConfig.loadXmlFromString()`: loads the configuration from the provided `String` containing XML configuration 
 
 The sample `XmlJetConfigClasspath` loads the jet configuration `hazelcast-jet-sample.xml` from the classpath and 
 demonstrates variable replacement in XML configuration by defining the backup count and metrics configuration

--- a/learning-basics/configure-xml/pom.xml
+++ b/learning-basics/configure-xml/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>learning-basics</artifactId>
+        <groupId>com.hazelcast.jet.samples</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>configure-xml</artifactId>
+
+    <name>Learning Basics - Configure XML</name>
+    <description>Learning Basics - Configure XML</description>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/learning-basics/configure-xml/src/main/java/ConfigLookup.java
+++ b/learning-basics/configure-xml/src/main/java/ConfigLookup.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.MetricsConfig;
+import com.hazelcast.jet.impl.config.XmlJetConfigBuilder;
+
+public class ConfigLookup {
+    public static void main(String[] args) {
+        // XML takes precedence: loading jet configuration hazelcast-jet.xml from the classpath
+        // despite the presence of hazelcast-jet.yaml
+        JetInstance jet = Jet.newJetInstance();
+        InstanceConfig instanceConfig = jet.getConfig().getInstanceConfig();
+        MetricsConfig metricsConfig = jet.getConfig().getMetricsConfig();
+        // the jet instance uses backup count of 1 and metrics disabled as configured in hazelcast-jet.xml
+        // the underlying hazelcast member uses the port (7000) from the hazelcast.xml
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+        jet.shutdown();
+
+
+        // loading configuration from hazelcast-jet.xml from the classpath by using XML-specific config builder
+        JetConfig config = new XmlJetConfigBuilder().build();
+        // the jet instance uses backup count of 1 and metrics disabled as configured in hazelcast-jet.xml
+        // the underlying hazelcast member uses the port (7000) from the hazelcast.xml
+        jet = Jet.newJetInstance(config);
+        instanceConfig = jet.getConfig().getInstanceConfig();
+        metricsConfig = jet.getConfig().getMetricsConfig();
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+
+        // loading the client configuration from hazelcast-client.xml
+        JetInstance client = Jet.newJetClient();
+        // the client is connected to the jet instance running on port 7000
+
+        client.shutdown();
+        jet.shutdown();
+    }
+
+}

--- a/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
+++ b/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
@@ -27,7 +27,8 @@ public class XmlJetConfigClasspath {
         // taking the metrics and backup configuration from system properties.
         System.setProperty("metricsEnabled", "true");
         System.setProperty("backupCount", "4");
-        JetConfig config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.xml");
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        JetConfig config = JetConfig.loadFromClasspath(classLoader, "hazelcast-jet-sample.xml");
         JetInstance jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();
@@ -36,7 +37,7 @@ public class XmlJetConfigClasspath {
         Properties configProperties = new Properties();
         configProperties.setProperty("metricsEnabled", "true");
         configProperties.setProperty("backupCount", "4");
-        config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.xml", configProperties);
+        config = JetConfig.loadFromClasspath(classLoader, "hazelcast-jet-sample.xml", configProperties);
         jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();

--- a/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
+++ b/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ClasspathXmlJetConfig;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.MetricsConfig;
+
+import java.util.Properties;
+
+public class XmlJetConfigClasspath {
+    public static void main(String[] args) throws Exception {
+        // taking the metrics and backup configuration from system properties.
+        System.setProperty("metricsEnabled", "true");
+        System.setProperty("backupCount", "4");
+        JetConfig config = new ClasspathXmlJetConfig("hazelcast-jet-sample.xml");
+        JetInstance jet = Jet.newJetInstance(config);
+        printInstanceAndMetricsConfig(jet);
+        jet.shutdown();
+
+        // taking the metrics and backup configuration from provided properties instance
+        Properties configProperties = new Properties();
+        configProperties.setProperty("metricsEnabled", "true");
+        configProperties.setProperty("backupCount", "4");
+        config = new ClasspathXmlJetConfig("hazelcast-jet-sample.xml", configProperties);
+        jet = Jet.newJetInstance(config);
+        printInstanceAndMetricsConfig(jet);
+        jet.shutdown();
+    }
+
+    private static void printInstanceAndMetricsConfig(JetInstance jet) {
+        InstanceConfig instanceConfig = jet.getConfig().getInstanceConfig();
+        MetricsConfig metricsConfig = jet.getConfig().getMetricsConfig();
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+    }
+}

--- a/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
+++ b/learning-basics/configure-xml/src/main/java/XmlJetConfigClasspath.java
@@ -16,7 +16,6 @@
 
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.config.ClasspathXmlJetConfig;
 import com.hazelcast.jet.config.InstanceConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
@@ -28,7 +27,7 @@ public class XmlJetConfigClasspath {
         // taking the metrics and backup configuration from system properties.
         System.setProperty("metricsEnabled", "true");
         System.setProperty("backupCount", "4");
-        JetConfig config = new ClasspathXmlJetConfig("hazelcast-jet-sample.xml");
+        JetConfig config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.xml");
         JetInstance jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();
@@ -37,7 +36,7 @@ public class XmlJetConfigClasspath {
         Properties configProperties = new Properties();
         configProperties.setProperty("metricsEnabled", "true");
         configProperties.setProperty("backupCount", "4");
-        config = new ClasspathXmlJetConfig("hazelcast-jet-sample.xml", configProperties);
+        config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.xml", configProperties);
         jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-client.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-client.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config">
+    <network>
+        <cluster-members>
+            <address>127.0.0.1:7000</address>
+        </cluster-members>
+    </network>
+    <group>
+        <name>dev-configured-from-xml</name>
+        <password>1234</password>
+    </group>
+</hazelcast-client>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-jet-sample.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-jet-sample.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.1.xsd"
+               xmlns="http://www.hazelcast.com/schema/jet-config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <instance>
+        <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
+        <backup-count>${backupCount}</backup-count>
+    </instance>
+
+    <metrics enabled="${metricsEnabled}"/>
+</hazelcast-jet>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-jet.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-jet.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.1.xsd"
+               xmlns="http://www.hazelcast.com/schema/jet-config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <instance>
+        <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
+        <backup-count>1</backup-count>
+    </instance>
+
+    <metrics enabled="false"/>
+</hazelcast-jet>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-jet.yaml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-jet.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast-jet:
+  instance:
+    backup-count: 1
+  metrics:
+    enabled: false

--- a/learning-basics/configure-xml/src/main/resources/hazelcast.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast.xml
@@ -1,0 +1,15 @@
+<hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                               http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd"
+           xmlns="http://www.hazelcast.com/schema/config">
+    <network>
+        <port>7000</port>
+        <interfaces>
+            <interface>127.0.0.1</interface>
+        </interfaces>
+    </network>
+    <group>
+        <name>dev-configured-from-xml</name>
+        <password>1234</password>
+    </group>
+</hazelcast>

--- a/learning-basics/configure-yaml/README.md
+++ b/learning-basics/configure-yaml/README.md
@@ -1,0 +1,46 @@
+# YAML Configuration
+
+The samples in this module demonstrate how to configure a Hazelcast Jet cluster with YAML configuration.
+
+### Configuration Lookup
+
+Creating member instance with `Jet.newJetInstance()` looks for configuration files
+in multiple locations both in XML and YAML format. XML configuration takes precedence
+over YAML configuration in all locations resulting the following lookup order:
+1. The configuration passed in `hazelcast.jet.config` JVM argument, either XML or YAML
+2. `hazelcast-jet.xml` on the classpath
+3. `hazelcast-jet.yaml` on the classpath
+4. `hazelcast-jet.xml` in the working directory
+5. `hazelcast-jet.yaml` in the working directory
+6. default configuration `hazelcast-jet-default.xml`
+
+Similarly, the (Java) client instances created with `Jet.newJetClient()` follows
+the same lookup logic and order:
+1. The configuration passed in `hazelcast.client.config` JVM argument, either XML or YAML
+2. `hazelcast-client.xml` on the classpath
+3. `hazelcast-client.yaml` on the classpath
+4. `hazelcast-client.xml` in the working directory
+5. `hazelcast-client.yaml` in the working directory
+6. default configuration `hazelcast-jet-client-default.xml`
+
+The sample `ConfigLookup` demonstrates how the configuration files are located on the classpath and 
+how to use the locator logic to take only YAML configuration files into account. 
+
+### Loading YAML Configuration Without Lookup
+
+If it is known that the cluster will be configured with YAML configuration and no need for using the location 
+logic shown in the first sample, the following YAML-specific `JetConfig` classes can be used:
+- `ClasspathYamlJetConfig`: loads the configuration from the classpath based on the provided filename
+- `FileSystemYamlJetConfig`: loads the configuration from the file system based on the provided filename
+- `UrlYamlJetConfig`: loads the configuration from the provided URL
+- `InMemoryYamlJetConfig`: loads the configuration from the provided `String` containing YAML configuration 
+
+The sample `YamlJetConfigClasspath` loads the jet configuration `hazelcast-jet-sample.yaml` from the classpath and 
+demonstrates variable replacement in YAML configuration by defining the backup count and metrics configuration
+in variables taken from the system properties and then from a provided `Properties` instance.   
+
+#### Full YAML Configuration Example
+
+There is a full example YAML configuration in the distributed Hazelcast Jet jars, named `hazelcast-jet-full-example.yaml`.
+In the lack of schema definitions and hence lack of auto-completion in IDEs this example file can be used
+for reference when writing YAML configuration.

--- a/learning-basics/configure-yaml/README.md
+++ b/learning-basics/configure-yaml/README.md
@@ -1,6 +1,7 @@
 # YAML Configuration
 
-The samples in this module demonstrate how to configure a Hazelcast Jet cluster with YAML configuration.
+The samples in this module demonstrate how to configure a Hazelcast Jet cluster
+ with YAML configuration.
 
 ### Configuration Lookup
 
@@ -9,8 +10,8 @@ in multiple locations both in XML and YAML format. XML configuration takes prece
 over YAML configuration in all locations resulting the following lookup order:
 1. The configuration passed in `hazelcast.jet.config` JVM argument, either XML or YAML
 2. `hazelcast-jet.xml` on the classpath
-3. `hazelcast-jet.yaml` on the classpath
-4. `hazelcast-jet.xml` in the working directory
+3. `hazelcast-jet.xml` in the working directory
+4. `hazelcast-jet.yaml` on the classpath
 5. `hazelcast-jet.yaml` in the working directory
 6. default configuration `hazelcast-jet-default.xml`
 
@@ -18,8 +19,8 @@ Similarly, the (Java) client instances created with `Jet.newJetClient()` follows
 the same lookup logic and order:
 1. The configuration passed in `hazelcast.client.config` JVM argument, either XML or YAML
 2. `hazelcast-client.xml` on the classpath
-3. `hazelcast-client.yaml` on the classpath
-4. `hazelcast-client.xml` in the working directory
+3. `hazelcast-client.xml` in the working directory
+4. `hazelcast-client.yaml` on the classpath
 5. `hazelcast-client.yaml` in the working directory
 6. default configuration `hazelcast-jet-client-default.xml`
 
@@ -29,11 +30,12 @@ how to use the locator logic to take only YAML configuration files into account.
 ### Loading YAML Configuration Without Lookup
 
 If it is known that the cluster will be configured with YAML configuration and no need for using the location 
-logic shown in the first sample, the following YAML-specific `JetConfig` classes can be used:
-- `ClasspathYamlJetConfig`: loads the configuration from the classpath based on the provided filename
-- `FileSystemYamlJetConfig`: loads the configuration from the file system based on the provided filename
-- `UrlYamlJetConfig`: loads the configuration from the provided URL
-- `InMemoryYamlJetConfig`: loads the configuration from the provided `String` containing YAML configuration 
+logic shown in the first sample, the following YAML-specific config loader utility methods on the `JetConfig` 
+class can be used:
+- `JetConfig.loadFromClasspath()` : loads the configuration from the classpath based on the provided filename
+- `JetConfig.loadFromFile()`      : loads the configuration from the file system based on the provided filename
+- `JetConfig.loadYamlFromStream()`: loads the configuration from the provided input stream
+- `JetConfig.loadYamlFromString()`: loads the configuration from the provided `String` containing YAML configuration 
 
 The sample `YamlJetConfigClasspath` loads the jet configuration `hazelcast-jet-sample.yaml` from the classpath and 
 demonstrates variable replacement in YAML configuration by defining the backup count and metrics configuration

--- a/learning-basics/configure-yaml/pom.xml
+++ b/learning-basics/configure-yaml/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>learning-basics</artifactId>
+        <groupId>com.hazelcast.jet.samples</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>configure-yaml</artifactId>
+
+    <name>Learning Basics - Configure YAML</name>
+    <description>Learning Basics - Configure YAML</description>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+
+</project>

--- a/learning-basics/configure-yaml/src/main/java/ConfigLookup.java
+++ b/learning-basics/configure-yaml/src/main/java/ConfigLookup.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.MetricsConfig;
+import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
+
+public class ConfigLookup {
+    public static void main(String[] args) {
+        // XML takes precedence: loading jet configuration hazelcast-jet.xml from the classpath
+        // despite the presence of hazelcast-jet.yaml
+        JetInstance jet = Jet.newJetInstance();
+        InstanceConfig instanceConfig = jet.getConfig().getInstanceConfig();
+        MetricsConfig metricsConfig = jet.getConfig().getMetricsConfig();
+        // the jet instance uses backup count of 3 and metrics enabled as configured in hazelcast-jet.xml
+        // the underlying hazelcast member uses default port (5701) from the hazelcast-jet-member-default.xml
+        // in the JAR package.
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+        jet.shutdown();
+
+        // loading configuration from hazelcast-jet.yaml from the classpath without looking for XML files
+        // by using YAML-specific config builder
+        JetConfig config = new YamlJetConfigBuilder().build();
+        // the jet instance uses backup count of 1 and metrics disabled as configured in hazelcast-jet.yaml
+        // the underlying hazelcast member uses the port (7000) from the hazelcast.yaml
+        jet = Jet.newJetInstance(config);
+        instanceConfig = jet.getConfig().getInstanceConfig();
+        metricsConfig = jet.getConfig().getMetricsConfig();
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+
+        // loading the client configuration from hazelcast-client.yaml since no hazelcast-client.xml
+        // is present on the classpath
+        JetInstance client = Jet.newJetClient();
+        // the client is connected to the jet instance running on port 7000
+
+        client.shutdown();
+        jet.shutdown();
+    }
+
+}

--- a/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
+++ b/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ClasspathYamlJetConfig;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.MetricsConfig;
+
+import java.util.Properties;
+
+public class YamlJetConfigClasspath {
+    public static void main(String[] args) throws Exception {
+        // taking the metrics and backup configuration from system properties.
+        System.setProperty("metricsEnabled", "true");
+        System.setProperty("backupCount", "4");
+        JetConfig config = new ClasspathYamlJetConfig("hazelcast-jet-sample.yaml");
+        JetInstance jet = Jet.newJetInstance(config);
+        printInstanceAndMetricsConfig(jet);
+        jet.shutdown();
+
+        // taking the metrics and backup configuration from provided properties instance
+        Properties configProperties = new Properties();
+        configProperties.setProperty("metricsEnabled", "true");
+        configProperties.setProperty("backupCount", "4");
+        config = new ClasspathYamlJetConfig("hazelcast-jet-sample.yaml", configProperties);
+        jet = Jet.newJetInstance(config);
+        printInstanceAndMetricsConfig(jet);
+        jet.shutdown();
+    }
+
+    private static void printInstanceAndMetricsConfig(JetInstance jet) {
+        InstanceConfig instanceConfig = jet.getConfig().getInstanceConfig();
+        MetricsConfig metricsConfig = jet.getConfig().getMetricsConfig();
+        System.out.println("Backup-count: " + instanceConfig.getBackupCount()
+                + ", Metrics enabled:" + metricsConfig.isEnabled()
+        );
+    }
+}

--- a/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
+++ b/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
@@ -27,7 +27,8 @@ public class YamlJetConfigClasspath {
         // taking the metrics and backup configuration from system properties.
         System.setProperty("metricsEnabled", "true");
         System.setProperty("backupCount", "4");
-        JetConfig config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.yaml");
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        JetConfig config = JetConfig.loadFromClasspath(classLoader, "hazelcast-jet-sample.yaml");
         JetInstance jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();
@@ -36,7 +37,7 @@ public class YamlJetConfigClasspath {
         Properties configProperties = new Properties();
         configProperties.setProperty("metricsEnabled", "true");
         configProperties.setProperty("backupCount", "4");
-        config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.yaml", configProperties);
+        config = JetConfig.loadFromClasspath(classLoader, "hazelcast-jet-sample.yaml", configProperties);
         jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();

--- a/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
+++ b/learning-basics/configure-yaml/src/main/java/YamlJetConfigClasspath.java
@@ -16,7 +16,6 @@
 
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.config.ClasspathYamlJetConfig;
 import com.hazelcast.jet.config.InstanceConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
@@ -28,7 +27,7 @@ public class YamlJetConfigClasspath {
         // taking the metrics and backup configuration from system properties.
         System.setProperty("metricsEnabled", "true");
         System.setProperty("backupCount", "4");
-        JetConfig config = new ClasspathYamlJetConfig("hazelcast-jet-sample.yaml");
+        JetConfig config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.yaml");
         JetInstance jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();
@@ -37,7 +36,7 @@ public class YamlJetConfigClasspath {
         Properties configProperties = new Properties();
         configProperties.setProperty("metricsEnabled", "true");
         configProperties.setProperty("backupCount", "4");
-        config = new ClasspathYamlJetConfig("hazelcast-jet-sample.yaml", configProperties);
+        config = JetConfig.loadFromClasspath(Thread.currentThread().getContextClassLoader(), "hazelcast-jet-sample.yaml", configProperties);
         jet = Jet.newJetInstance(config);
         printInstanceAndMetricsConfig(jet);
         jet.shutdown();

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast-client.yaml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast-client.yaml
@@ -1,0 +1,7 @@
+hazelcast-client:
+  network:
+    cluster-members:
+      - 127.0.0.1:7000
+  group:
+    name: dev-configured-from-yaml
+    password: 1234

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast-jet-sample.yaml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast-jet-sample.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast-jet:
+  instance:
+    backup-count: ${backupCount}
+  metrics:
+    enabled: ${metricsEnabled}

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast-jet.xml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast-jet.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.1.xsd"
+               xmlns="http://www.hazelcast.com/schema/jet-config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <instance>
+        <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
+        <backup-count>3</backup-count>
+    </instance>
+
+    <metrics enabled="true"/>
+</hazelcast-jet>

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast-jet.yaml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast-jet.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast-jet:
+  instance:
+    backup-count: 1
+  metrics:
+    enabled: false

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast.yaml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast.yaml
@@ -1,0 +1,9 @@
+hazelcast:
+  network:
+    port:
+      port: 7000
+    interfaces:
+      - 127.0.0.1
+  group:
+    name: dev-configured-from-yaml
+    password: 1234

--- a/learning-basics/pom.xml
+++ b/learning-basics/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>hazelcast-jet-code-samples</artifactId>
+        <groupId>com.hazelcast.jet.samples</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>learning-basics</artifactId>
+
+    <name>Learning Basics</name>
+    <description>Code samples for Hazelcast Jet related to configuration and logging basics.</description>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>configure-logging</module>
+        <module>configure-yaml</module>
+        <module>configure-xml</module>
+    </modules>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>tf-idf</module>
         <module>wordcount</module>
         <module>jdbc</module>
+        <module>learning-basics</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Introduced learning-basics module with the following sub-modules:
- configure-xml
- configure-yaml
- conifgure-logging

Depends on https://github.com/hazelcast/hazelcast-jet/pull/1371